### PR TITLE
Use eslint-config-xo-nextjs to allow ES20xx

### DIFF
--- a/components/demo/try-geo.js
+++ b/components/demo/try-geo.js
@@ -2,9 +2,9 @@ import React from 'react'
 import debounce from 'debounce'
 import dynamic from 'next/dynamic'
 
-import TryContainer from './try-container'
 import Loader from '../loader'
 import Notification from '../notification'
+import TryContainer from './try-container'
 import Commune from './commune'
 
 const LeafletMap = dynamic(import('../leaflet-map'), {
@@ -69,6 +69,8 @@ class TryGeo extends React.Component {
   }
 
   render() {
+    // TODO: use `error` state and remove the eslint comment
+    // eslint-disable-next-line no-unused-vars
     const {position, results, loading, error} = this.state
     const commune = results.length > 0 ? results[0] : null
 
@@ -77,10 +79,10 @@ class TryGeo extends React.Component {
         <div className='container'>
           {commune ?
             <LeafletMap
-                data={commune.contour}
-                position={[position.coords.latitude, position.coords.longitude]}
-                center={commune.centre.coordinates.reverse()}
-                zoom={12.5} /> :
+              data={commune.contour}
+              position={[position.coords.latitude, position.coords.longitude]}
+              center={commune.centre.coordinates.reverse()}
+              zoom={12.5} /> :
             <LeafletMap />
           }
 
@@ -88,7 +90,7 @@ class TryGeo extends React.Component {
             {loading ?
               <div className='loading'>
                 <Notification message='Le temps de chargement n’est pas représentatif des performances de l’API ' type='info' />
-                <Loader size={'big'} text='Chargement…' />
+                <Loader size='big' text='Chargement…' />
               </div> :
               <Commune commune={commune} onClick={this.handleLocation} />
             }

--- a/components/demo/try-name.js
+++ b/components/demo/try-name.js
@@ -23,9 +23,12 @@ class TryName extends React.Component {
   }
 
   updateValue(value) {
-    const {boost} = this.state
-    const url = `https://geo.api.gouv.fr/communes?nom=${value}&fields=departement${boost ? '&boost=population' : ''}`
-    this.setState({value, results: [], loading: true}, this.search(url))
+    this.setState({value, results: [], loading: true}, () => {
+      const {boost} = this.state
+
+      const url = `https://geo.api.gouv.fr/communes?nom=${value}&fields=departement${boost ? '&boost=population' : ''}`
+      this.search(url)
+    })
   }
 
   search(url) {
@@ -57,7 +60,9 @@ class TryName extends React.Component {
   }
 
   toggleBoost() {
-    this.setState({boost: !this.state.boost})
+    this.setState(state => ({
+      boost: !state.boost
+    }))
   }
 
   render() {
@@ -69,7 +74,7 @@ class TryName extends React.Component {
           value={value}
           results={results}
           loading={loading}
-          placeholder={'Rechercher une commune…'}
+          placeholder='Rechercher une commune…'
           search={this.updateValue} />
         <SwitchInput handleChange={this.toggleBoost} label='Boost de population' isChecked={boost} />
       </TryContainer>

--- a/components/examples/advanced-search.js
+++ b/components/examples/advanced-search.js
@@ -515,7 +515,7 @@ const json = `[
 ]`
 
 const AdvancedSearch = () => (
-  <Section background={'white'}>
+  <Section background='white'>
     <Tuto
       title='Recherche avancée'
       description='Le paramètre fields vous permet de filtrer les informations.'
@@ -524,7 +524,8 @@ const AdvancedSearch = () => (
       code={json}
       tips='Le paramètre format permet de préciser un format de sortie des données (json/geojson).'
       warning='Le format GeoJSON implique de choisir une géométrie principale. Par défaut il s’agit du centre. Cela peut être changé en ajoutant le paramètre geometry=contour.'
-      side='right' >
+      side='right'
+    >
 
       <div>
         <div><b>Champs possibles</b> :</div>

--- a/components/examples/by-code.js
+++ b/components/examples/by-code.js
@@ -18,7 +18,7 @@ const json = `[
 ]`
 
 const ByCode = () => (
-  <Section background={'grey'}>
+  <Section background='grey'>
     <Tuto
       title='Recherche par code postal'
       description='Il est possible de rechercher une commune avec son code postal.'

--- a/components/examples/by-lat-lon.js
+++ b/components/examples/by-lat-lon.js
@@ -16,7 +16,7 @@ const json = `{
 }`
 
 const ByLatLon = () => (
-  <Section background={'grey'}>
+  <Section background='grey'>
     <Tuto
       title='Recherche géographique'
       description='Les variables lon et lat permettent d’effectuer une recherche géographique.'

--- a/components/examples/by-name.js
+++ b/components/examples/by-name.js
@@ -19,7 +19,7 @@ const json = `[
 ]`
 
 const ByName = () => (
-  <Section background={'white'}>
+  <Section background='white'>
     <Tuto
       title='Recherche par nom'
       description='La variable nom vous permet d’effectuer une recherche de communes par nom.'

--- a/components/home/subscribe.js
+++ b/components/home/subscribe.js
@@ -10,7 +10,8 @@ export default () => (
       <Button type='submit' name='subscribe' style={{
         width: '100%',
         textTransform: 'uppercase'
-      }}>
+      }}
+      >
         Inscription
       </Button>
     </form>

--- a/components/leaflet-map.js
+++ b/components/leaflet-map.js
@@ -1,5 +1,4 @@
 /* eslint react/no-danger: off */
-import React from 'react'
 import PropTypes from 'prop-types'
 import L from 'leaflet'
 import {Map, TileLayer, Marker, GeoJSON} from 'react-leaflet'

--- a/package.json
+++ b/package.json
@@ -27,45 +27,19 @@
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {
-    "eslint-config-xo-react": "^0.13.0",
+    "babel-eslint": "^8.0.3",
+    "eslint-config-xo-nextjs": "^1.2.0",
     "eslint-plugin-react": "^7.4.0",
     "webpack-bundle-analyzer": "^2.9.1",
     "xo": "^0.18.2"
   },
   "xo": {
-    "extends": "xo-react",
+    "extends": "xo-nextjs",
     "semicolon": false,
     "space": 2,
-    "globals": [
-      "fetch"
-    ],
+    "env": "browser",
     "rules": {
-      "jsx-quotes": [
-        "error",
-        "prefer-single"
-      ],
-      "react/jsx-closing-bracket-location": [
-        "error",
-        "after-props"
-      ],
-      "react/jsx-closing-tag-location": "off",
-      "react/jsx-first-prop-new-line": "off",
-      "react/jsx-max-props-per-line": [
-        "warn",
-        {
-          "maximum": 4,
-          "when": "multiline"
-        }
-      ],
-      "react/jsx-tag-spacing": [
-        "error",
-        {
-          "closingSlash": "never",
-          "beforeSelfClosing": "always",
-          "afterOpening": "never"
-        }
-      ],
-      "react/forbid-component-props": "off",
+      "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off"
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,58 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz#2349d7ec04b3a06945ae173280ef8579b63728e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz#366e3bc35147721b69009f803907c4d53212e88d"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.36"
+    "@babel/template" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/helper-get-function-arity@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz#f5383bac9a96b274828b10d98900e84ee43e32b8"
+  dependencies:
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/template@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.36.tgz#1dc6f8750e89b6b979de5fe44aa993b1a2192261"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/helper-function-name" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    debug "^3.0.1"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.36.tgz#64f2004353de42adb72f9ebb4665fc35b5499d23"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@semantic-release/commit-analyzer@^3.0.1":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-3.0.7.tgz#dc955444a6d3d2ae9b8e21f90c2c80c4e9142b2f"
@@ -345,6 +397,17 @@ babel-core@6.26.0, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.0.3:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.1.tgz#136888f3c109edc65376c23ebf494f36a3e03951"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/traverse" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@6.26.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -902,6 +965,10 @@ babel-types@6.26.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+babylon@7.0.0-beta.36:
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.36.tgz#3a3683ba6a9a1e02b0aa507c8e63435e39305b9e"
+
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
@@ -1186,7 +1253,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1587,7 +1654,7 @@ debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -1941,9 +2008,15 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-xo-react@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.13.0.tgz#63518dbd8a87f0700f0861fbb6ac0fb5efdf6039"
+eslint-config-xo-nextjs@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo-nextjs/-/eslint-config-xo-nextjs-1.2.0.tgz#a163d06522926e7c1b33ba5837e473c78b4463ec"
+  dependencies:
+    eslint-config-xo-react "^0.15.0"
+
+eslint-config-xo-react@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.15.0.tgz#9dd9858cbeff2094d775db25ffb5f79b98c546e4"
 
 eslint-config-xo@^0.18.0:
   version "0.18.2"
@@ -2032,6 +2105,17 @@ eslint-plugin-unicorn@^2.1.0:
     lodash.kebabcase "^4.0.1"
     lodash.snakecase "^4.0.1"
     lodash.upperfirst "^4.2.0"
+
+eslint-scope@~3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^3.18.0:
   version "3.19.0"
@@ -2625,6 +2709,10 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+
 globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2993,7 +3081,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3560,7 +3648,7 @@ lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5461,6 +5549,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 toggle-selection@^1.0.3:
   version "1.0.6"


### PR DESCRIPTION
Just make sure not to upgrade babel-eslint to the latest version.

This also allows class properties, so you can get rid of all the `.bind`s in component constructors.

```js
onSomething = e => {
  e.preventDefault()
}
```